### PR TITLE
Maintenance: account for accrued fees in global Line check test

### DIFF
--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -1301,7 +1301,7 @@ contract DssSpellTestBase is Config, DssTest {
     function _checkCollateralValues(SystemValues storage values) internal {
         // Using an array to work around stack depth limitations.
         // sums[0] : sum of all lines
-        // sums[1] : sum over ilks of (line - Art * rate)--i.e. debt that could be drawn at any time
+        // sums[1] : sum of debt that can be drawn at integer Art precision
         // sums[2] : accrued stability fees not yet materialized in vat.debt() after all drawable debt is drawn
         uint256[] memory sums = new uint256[](3);
         bytes32[] memory ilks = reg.list();
@@ -1354,7 +1354,8 @@ contract DssSpellTestBase is Config, DssTest {
             (Art, rate,, line, dust) = vat.ilks(ilk);
             uint256 debt = Art * rate;
             if (debt < line) {
-                sums[1] += line - debt;
+                uint256 maxDrawableArt = line / rate;
+                sums[1] += (maxDrawableArt - Art) * rate;
             }
 
             sums[2] += _getUnmaterializedFees(ilk, Art, rate, line);

--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -943,6 +943,15 @@ contract DssSpellTestBase is Config, DssTest {
             expectedRate_ - yearlyYield_ : yearlyYield_ - expectedRate_;
     }
 
+    function _getUnmaterializedFees(bytes32 ilk, uint256 Art, uint256 rate, uint256 line) internal view returns (uint256) {
+        (uint256 duty, uint256 rho) = jug.ilks(ilk);
+        // Assume all currently drawable debt is drawn before fees are materialized.
+        uint256 maxArtForFeeAccrual = Art * rate < line ? line / rate : Art;
+        uint256 projectedRate = _rpow(jug.base() + duty, block.timestamp - rho, RAY) * rate / RAY;
+
+        return maxArtForFeeAccrual * (projectedRate - rate);
+    }
+
     function _castPreviousSpell() internal {
         address[] memory prevSpells = spellValues.previous_spells;
 
@@ -1293,11 +1302,12 @@ contract DssSpellTestBase is Config, DssTest {
         // Using an array to work around stack depth limitations.
         // sums[0] : sum of all lines
         // sums[1] : sum over ilks of (line - Art * rate)--i.e. debt that could be drawn at any time
-        uint256[] memory sums = new uint256[](2);
+        // sums[2] : accrued stability fees not yet materialized in vat.debt() after all drawable debt is drawn
+        uint256[] memory sums = new uint256[](3);
         bytes32[] memory ilks = reg.list();
         for(uint256 i = 0; i < ilks.length; i++) {
             bytes32 ilk = ilks[i];
-            (uint256 duty,)  = jug.ilks(ilk);
+            (uint256 duty,) = jug.ilks(ilk);
 
             {
             if (!values.collaterals[ilk].SP_enabled) {
@@ -1342,9 +1352,12 @@ contract DssSpellTestBase is Config, DssTest {
             uint256 Art;
             uint256 rate;
             (Art, rate,, line, dust) = vat.ilks(ilk);
-            if (Art * rate < line) {
-                sums[1] += line - Art * rate;
+            uint256 debt = Art * rate;
+            if (debt < line) {
+                sums[1] += line - debt;
             }
+
+            sums[2] += _getUnmaterializedFees(ilk, Art, rate, line);
             }
             sums[0] += line;
             (uint256 aL_line, uint256 aL_gap, uint256 aL_ttl,,) = autoLine.ilks(ilk);
@@ -1488,9 +1501,8 @@ contract DssSpellTestBase is Config, DssTest {
                 }
             }
         }
-        // Require that debt + (debt that could be drawn) does not exceed Line.
-        // TODO: consider a buffer for fee accrual
-        assertTrue(vat.debt() + sums[1] <= vat.Line(), "TestError/vat-Line-1");
+        // Require that debt + (debt that could be drawn) + unmaterialized fees does not exceed Line.
+        assertLe(vat.debt() + sums[1] + sums[2], vat.Line(), "TestError/vat-Line-1");
 
         (,,, uint256 stusdsIlkLine,) = vat.ilks(stusds.ilk());
         uint256 stusdsAvailableLineIncrease = rateSetter.maxLine() - stusdsIlkLine;


### PR DESCRIPTION
# Maintenance Description

Implements the maintenance code for [issue #514](https://github.com/sky-ecosystem/spells-mainnet/issues/514).

---

## What does this PR do?

- adds `_getUnmaterializedFees` to calculate stability fees accrued since each ilk’s last `Jug.drip`;
- calculates `maxArtForFeeAccrual`, assuming all currently drawable debt is drawn before fees are materialized;
- accumulates unmaterialized fees for every registered ilk in `sums[2]`;
- strengthens `TestError/vat-Line-1` to require that materialized debt, drawable debt, and unmaterialized fees do not exceed the global `Vat.Line`.

The affected component is `src/DssSpell.t.base.sol`. No production contracts are modified.

## Why is this needed?

`vat.debt()` contains debt materialized at the rates currently stored in the Vat. Stability fees accrued since an ilk’s last `Jug.drip` are not yet reflected in that value.

The previous invariant checked:

```text
vat.debt() + drawable debt <= vat.Line()
```

This did not account for the sequence in which users draw the remaining available debt before `Jug.drip` materializes already-accrued stability fees.

The updated invariant checks:

```text
vat.debt() + drawable debt + unmaterialized fees <= vat.Line()
```

For each ilk:

- when current debt is below the local ceiling, fees are calculated using the maximum normalized debt drawable at the current rate;
- when current debt is at or above the local ceiling, fees are calculated using the existing normalized debt because no additional debt can be drawn;
- accrued fees are projected only from `rho` to the current block timestamp, without introducing an arbitrary future horizon.

This prevents a spell from passing the global debt-capacity check when an immediate draw-before-drip sequence could cause total debt to exceed `Vat.Line`.

## Context

- issue: [consider a buffer for fee accrual #514](https://github.com/sky-ecosystem/spells-mainnet/issues/514);
- fee accrual implementation: [Jug](https://github.com/sky-ecosystem/dss/blob/master/src/jug.sol#L121-L128).

## End-to-end testing

- setup: use the configured mainnet spell fork with an Ethereum RPC assigned to `ETH_RPC_URL`;
- commands or steps: run `make clean`, `make all`, `make test`;
- expected result: the project compiles, `testGeneral` executes the fee-aware collateral invariant successfully;
- actual result: compilation passed, `testGeneral` passed with zero failures.

## Scope and risks

- scope is limited to the reusable spell test harness in `DssSpell.t.base.sol`;
- no production contracts, debt ceilings, stability fees, or protocol state are modified;
- no fixed monetary buffer or future accrual horizon is introduced.