### PR TITLE
Add SafeHarbor recovery address config check

### DIFF
--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -615,6 +615,43 @@ interface ArbL2GovernanceRelayLike {
     function relay(address target, bytes calldata targetData) external;
 }
 
+interface SafeHarborAgreementLike {
+    struct Account {
+        string accountAddress;
+        uint8 childContractScope;
+    }
+
+    struct Contact {
+        string name;
+        string contact;
+    }
+
+    struct Chain {
+        string assetRecoveryAddress;
+        Account[] accounts;
+        string caip2ChainId;
+    }
+
+    struct BountyTerms {
+        uint256 bountyPercentage;
+        uint256 bountyCapUSD;
+        bool retainable;
+        uint8 identity;
+        string diligenceRequirements;
+        uint256 aggregateBountyCapUSD;
+    }
+
+    struct AgreementDetails {
+        string protocolName;
+        Contact[] contactDetails;
+        Chain[] chains;
+        BountyTerms bountyTerms;
+        string agreementURI;
+    }
+
+    function getDetails() external view returns (AgreementDetails memory details);
+}
+
 contract DssSpellTestBase is Config, DssTest {
     using stdStorage for StdStorage;
 
@@ -3362,6 +3399,60 @@ contract DssSpellTestBase is Config, DssTest {
         _checkSystemValues(afterSpell);
 
         _checkCollateralValues(afterSpell);
+    }
+
+    function _testSafeHarborRecoveryAddresses() internal {
+        address agreementAddress = addr.addr("SAFE_HARBOR_AGREEMENT");
+        assertEq(
+            chainLog.getAddress("SAFE_HARBOR_AGREEMENT"),
+            agreementAddress,
+            "TestError/safe-harbor-chainlog-address-before"
+        );
+
+        _vote(address(spell));
+        _scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done(), "TestError/spell-not-done");
+
+        assertEq(
+            chainLog.getAddress("SAFE_HARBOR_AGREEMENT"),
+            agreementAddress,
+            "TestError/safe-harbor-chainlog-address-after"
+        );
+
+        SafeHarborAgreementLike.AgreementDetails memory details =
+            SafeHarborAgreementLike(agreementAddress).getDetails();
+        SafeHarborChainValues[] storage expectedChains = afterSpell.safe_harbor_chains;
+
+        assertEq(
+            details.chains.length,
+            expectedChains.length,
+            "TestError/safe-harbor-chain-count"
+        );
+
+        for (uint256 i = 0; i < expectedChains.length; i++) {
+            bool found;
+            for (uint256 j = 0; j < details.chains.length; j++) {
+                if (_cmpStr(details.chains[j].caip2ChainId, expectedChains[i].caip2_chain_id)) {
+                    assertEq(
+                        details.chains[j].assetRecoveryAddress,
+                        expectedChains[i].asset_recovery_address,
+                        string.concat(
+                            "TestError/safe-harbor-recovery-address-",
+                            expectedChains[i].caip2_chain_id
+                        )
+                    );
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue(
+                found,
+                string.concat(
+                    "TestError/safe-harbor-chain-not-found-",
+                    expectedChains[i].caip2_chain_id
+                )
+            );
+        }
     }
 
     function _testOfficeHours() internal {

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -92,6 +92,11 @@ contract DssSpellTest is DssSpellTestBase {
         _testChainlogValues();
     }
 
+    // Leave this test always enabled as it acts as a config test
+    function testSafeHarborRecoveryAddresses() public {
+        _testSafeHarborRecoveryAddresses();
+    }
+
     function testSplitter() public {
         _testSplitter();
     }

--- a/src/test/config.sol
+++ b/src/test/config.sol
@@ -27,6 +27,11 @@ contract Config {
         uint256   expiration_threshold;
     }
 
+    struct SafeHarborChainValues {
+        string caip2_chain_id;
+        string asset_recovery_address;
+    }
+
     struct SystemValues {
         uint256 max_global_line_offset;
         uint256 pause_delay;
@@ -83,6 +88,7 @@ contract Config {
         uint16  stusds_rate_setter_maxDuty;
         uint16  stusds_rate_setter_dutyStep;
         address[] stusds_rate_setter_buds;
+        SafeHarborChainValues[] safe_harbor_chains;
     }
 
     enum UpdateMethod {
@@ -213,6 +219,36 @@ contract Config {
         address[] memory buds = new address[](1);
         buds[0] = 0xBB865F94B8A92E57f79fCc89Dfd4dcf0D3fDEA16;
         afterSpell.stusds_rate_setter_buds = buds; // Array of address
+
+        delete afterSpell.safe_harbor_chains;
+        afterSpell.safe_harbor_chains.push(SafeHarborChainValues({
+            caip2_chain_id: "eip155:1",
+            asset_recovery_address: "0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB"
+        }));
+        afterSpell.safe_harbor_chains.push(SafeHarborChainValues({
+            caip2_chain_id: "eip155:8453",
+            asset_recovery_address: "0xdD0BCc201C9E47c6F6eE68E4dB05b652Bb6aC255"
+        }));
+        afterSpell.safe_harbor_chains.push(SafeHarborChainValues({
+            caip2_chain_id: "eip155:42161",
+            asset_recovery_address: "0x10E6593CDda8c58a1d0f14C5164B376352a55f2F"
+        }));
+        afterSpell.safe_harbor_chains.push(SafeHarborChainValues({
+            caip2_chain_id: "eip155:10",
+            asset_recovery_address: "0x10E6593CDda8c58a1d0f14C5164B376352a55f2F"
+        }));
+        afterSpell.safe_harbor_chains.push(SafeHarborChainValues({
+            caip2_chain_id: "eip155:130",
+            asset_recovery_address: "0x3510a7F16F549EcD0Ef018DE0B3c2ad7c742990f"
+        }));
+        afterSpell.safe_harbor_chains.push(SafeHarborChainValues({
+            caip2_chain_id: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            asset_recovery_address: "AYPtjx4Hc8us1ikULUedkmZ3wtiD6tmL7gK3qe4V3oHt"
+        }));
+        afterSpell.safe_harbor_chains.push(SafeHarborChainValues({
+            caip2_chain_id: "eip155:43114",
+            asset_recovery_address: "0xe928885BCe799Ed933651715608155F01abA23cA"
+        }));
 
         //
         // Values for all collateral


### PR DESCRIPTION
This is a proposal implementation of a base config test for SafeHarbor recovery addresses, following existing config tests. It explicitly lists recovery addresses and chains in the spell config and checks them against the Agreement after the spell is cast. The recovery flow itself should be tested separately when a recovery address is added or changed.

Run:

```sh
make test match=SafeHarborRecoveryAddresses
```